### PR TITLE
Make it clear how to use swc-node

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,15 @@
   <a href="https://github.com/Brooooooklyn/swc-node/blob/master/LICENSE"><img src="https://img.shields.io/npm/l/@swc-node/core.svg?sanitize=true" alt="License" /></a>
 </p>
 
+## Usage
+
+Run TypeScript with node, without compilation or typechecking:
+
+```bash
+npm i -D @swc-node/register
+node -r @swc-node/register script.ts
+```
+
 ## Support matrix
 
 |                     | node10 | node12 | node14 | node16 |


### PR DESCRIPTION
swc-node is GREAT! BUT: I suspect you're losing many potential users because of the README.

Back in January, I wanted something to "run TypeScript with node". I was pointed to swc-node, and I looked at it, but dismissed because it wasn't clear what it did, or how to use it.

Then a few days ago, I was pointed to swc-node again. I looked at it again, and AGAIN I dismissed it because it wasn't clear what it did, or how to use it!

Here are some reasons I failed:

* The top-level README has lots of detail I don't care about. Support matrix right at the top, then detailed benchmarks. Could just say "fast and runs everywhere".
* Small links to sub-project READMEs are called "Detail", but those contain all the useful info! The "detail" is the support matrix and benchmarking.
* The name `@swc-node/register` means nothing to me. What is it registering? I didn't even visit that project README because it sounded irrelevant.
* `@swc-node/register` is listed last, but it's actually the user-facing project that I need to use.

Compare this with https://github.com/TypeStrong/ts-node. It says straight away what it is and how to use it.