### PR TITLE
feat(register): return addHook result to it can be reverted

### DIFF
--- a/packages/register/register.ts
+++ b/packages/register/register.ts
@@ -52,7 +52,7 @@ export function compile(
 
 export function register(options = readDefaultTsConfig()) {
   installSourceMapSupport()
-  addHook((code, filename) => compile(code, filename, options), {
+  return addHook((code, filename) => compile(code, filename, options), {
     exts: DEFAULT_EXTENSIONS,
   })
 }


### PR DESCRIPTION
Currently the `register` method doesn't return the result of `pirates#addHook`, which means you can't revert the registration of the hook. This is very useful in circumstances like `jest-config`, which temporarily registers the transform, reads the config file, then de-registers it. See below

https://github.com/facebook/jest/blob/199f9811ae68b15879cbe18b7ef7ebd61eefcf23/packages/jest-config/src/readConfigFileAndSetRootDir.ts#L83-L101