### PR TITLE
feat(register): support hook options

### DIFF
--- a/packages/register/register.ts
+++ b/packages/register/register.ts
@@ -50,9 +50,10 @@ export function compile(
   }
 }
 
-export function register(options = readDefaultTsConfig()) {
+export function register(options = readDefaultTsConfig(), hookOpts = {}) {
   installSourceMapSupport()
   return addHook((code, filename) => compile(code, filename, options), {
     exts: DEFAULT_EXTENSIONS,
+    ...hookOpts,
   })
 }


### PR DESCRIPTION
This adds the opportunity to transpile files within node_modules.

I'm not that familiar with the swc-node library so feel free to close/reimplement as you see fit but decided to leave this PR here to at least share visibility into what we hacked together for our own needs.

```typescript
const { register } = require('@swc-node/register/register')
register(/* use defaults */ undefined, {
  ignoreNodeModules: false,
  matcher: (filename) => {
    // Custom file matcher
    return !/node_modules\/(?!@someorg)/.test(filename)
  }
}
```

Side note: didn't mean to create this PR here, thought it would go to our own fork of swc-node when I ran `gh pr create` 😆 