### PR TITLE
fix(register): support paths alias with baseUrl

### DIFF
--- a/packages/register/read-default-tsconfig.ts
+++ b/packages/register/read-default-tsconfig.ts
@@ -126,6 +126,11 @@ export function tsCompilerOptionsToSwcConfig(options: ts.CompilerOptions, filena
     dynamicImport: true,
     esModuleInterop: options.esModuleInterop ?? false,
     keepClassNames: true,
-    paths: options.paths as Options['paths'],
+    paths: Object.fromEntries(
+      Object.entries(options.paths ?? {}).map(([aliasKey, aliasPaths]) => [
+        aliasKey,
+        (aliasPaths as string[] ?? []).map((path) => resolve(options.baseUrl ?? './', path)),
+      ]),
+    ) as Options['paths'],
   }
 }


### PR DESCRIPTION
At the moment, swc-node raise an error if we defined `paths` in `tsconfig.json`

For example: 
```json
{
  "compilerOptions": {
    "baseUrl": "./src",
    "paths": {
         "@api/*": ["api/*"]
     }
  }
}
```

```
Error: Cannot find module '../../../../../api/http-service
```

This pull request is to convert options.paths to absolute paths