### PR TITLE
fix(sourcemap-support): add "tslib" as a dependnecy for "sourcemap-suport"

### DIFF
--- a/packages/sourcemap-support/package.json
+++ b/packages/sourcemap-support/package.json
@@ -18,7 +18,8 @@
     "url": "git+https://github.com/swc-project/swc-node.git"
   },
   "dependencies": {
-    "source-map-support": "^0.5.21"
+    "source-map-support": "^0.5.21",
+    "tslib": "^2.4.0"
   },
   "bugs": {
     "url": "https://github.com/swc-project/swc-node/issues"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -154,8 +154,10 @@ importers:
     specifiers:
       '@types/source-map-support': ^0.5.6
       source-map-support: ^0.5.21
+      tslib: ^2.4.0
     dependencies:
       source-map-support: 0.5.21
+      tslib: 2.4.0
     devDependencies:
       '@types/source-map-support': 0.5.6
 


### PR DESCRIPTION
Compiled code of this package requires "tslib" to be installed which is not the case if the porject has "@swc-node/register" as a single dependency.

In that case `npm` will generate the following tree:

```
- node_modules
  - @swc-node
    - sourcemap-support
    - register
      - node_modules
        - tslib
```

and `tslib` will be insaccessible for "@swc-node/sourcemap-support"