### PR TITLE
Add externalHelpers:true for jest

### DIFF
--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -35,6 +35,7 @@ function transformOption(path: string, options?: Options, jest = false): SwcOpti
     filename: path,
     jsc: {
       target: opts.target ?? DEFAULT_ES_TARGET,
+      externalHelpers: jest ? true : false,
       parser: {
         syntax: 'typescript' as const,
         tsx: typeof opts.jsx !== 'undefined' ? opts.jsx : path.endsWith('.tsx'),


### PR DESCRIPTION
Helper functions will show up in jest test coverage as uncovered lines.

I'm opening this PR because it was a quick change to propose, but there may be valid reasons not to do this.

Let me know if you'd like a reproduction of the issue, and happy to discuss further.