### PR TITLE
Fix sourcemap support installation instructions

### DIFF
--- a/packages/sourcemap-support/README.md
+++ b/packages/sourcemap-support/README.md
@@ -3,6 +3,8 @@
 ```ts
 import { SourcemapMap, installSourceMapSupport } from '@swc-node/sourcemap-support'
 
+installSourceMapSupport()
+
 function transform(sourcecode, filename, options) {
   const { code, map } = transformSync(sourcecode, filename, options)
   SourcemapMap.set(filename, map)


### PR DESCRIPTION
`SourcemapMap.set(filename, map)` doesn't do anything unless you've hooked up `installSourceMapSupport` I believe