### PR TITLE
Added SWCRC env variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,11 @@ npm i -D @swc-node/register
 node -r @swc-node/register script.ts
 ```
 
+Set environment variable SWCRC=true when you would like to load .swcrc file
+```bash
+SWCRC=true node -r @swc-node/register script.ts
+```
+
 ## Support matrix
 
 |                     | node10 | node12 | node14 | node16 |

--- a/packages/register/register.ts
+++ b/packages/register/register.ts
@@ -41,7 +41,14 @@ export function compile(
     }
     return outputText
   } else {
-    const { code, map } = transformSync(sourcecode, filename, tsCompilerOptionsToSwcConfig(options, filename))
+    const swcRegisterConfig = tsCompilerOptionsToSwcConfig(options, filename)
+    if (process.env.SWCRC === 'true') {
+      // when SWCRC environment variable is set to true it will use swcrc file
+      swcRegisterConfig.swc = {
+        swcrc: true,
+      }
+    }
+    const { code, map } = transformSync(sourcecode, filename, swcRegisterConfig)
     // in case of map is undefined
     if (map) {
       SourcemapMap.set(filename, map)


### PR DESCRIPTION
This PR adds the ability to load the .swcrc file when running the following command:

```
SWCRC=true node -r @swc-node/register index.ts
```

.swcrc file is needed in some scenarios, and there was no option to load it. For example, when you need to use a plugin, you need to use the following .swcrc file:

```json
{
  "jsc": {
    "experimental": {
      "plugins": [
        [
          "SWC-plugin-formatjs",
          {
            "overrideIdFn": "[sha512:contenthash:base64:6]"
          }
        ]
      ]
    }
  }
}
```

I have chosen an environment variable because it was the simplest solution with minimal impact. I did not want to cause breaking change, so it is opt-in rather than opt-out. This way, it can be a minor version bump.