### PR TITLE
Pass TypeScript peer dependency to consumer in jest package

### DIFF
--- a/packages/jest/package.json
+++ b/packages/jest/package.json
@@ -18,7 +18,8 @@
     "@swc-node/register": "^1.5.4"
   },
   "peerDependencies": {
-    "@swc/core": ">= 1.3"
+    "@swc/core": ">= 1.3",
+    "typescript": ">= 4.3"
   },
   "repository": {
     "type": "git",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -104,11 +104,13 @@ importers:
       '@swc-node/core': ^1.9.1
       '@swc-node/register': ^1.5.4
       '@swc/core': '>= 1.3'
+      typescript: '>= 4.3'
     dependencies:
       '@node-rs/xxhash': 1.2.1
       '@swc-node/core': link:../core
       '@swc-node/register': link:../register
       '@swc/core': 1.3.24
+      typescript: 4.9.4
 
   packages/loader:
     specifiers:
@@ -9408,7 +9410,6 @@ packages:
     resolution: {integrity: sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg==}
     engines: {node: '>=4.2.0'}
     hasBin: true
-    dev: true
 
   /uglify-js/3.15.4:
     resolution: {integrity: sha512-vMOPGDuvXecPs34V74qDKk4iJ/SN4vL3Ow/23ixafENYvtrNvtbcgUeugTcUGRGsOF/5fU8/NYSL5Hyb3l1OJA==}


### PR DESCRIPTION
This simply adds `typescript` as a peer dependency of the **@swc-node/jest** package, effectively passing the peer dependency requirement from **@swc-node/register** onto the consumer of **@swc-node/jest** in order to prevent the following warning:

<img width="1606" alt="peer-warning" src="https://user-images.githubusercontent.com/288160/206811328-f2b08cd8-d947-4587-bcf9-a595c2498068.png">
