### PR TITLE
fix(register): Fix to resolve adjacent file path

### DIFF
--- a/packages/integrate-module/src/foo.mts
+++ b/packages/integrate-module/src/foo.mts
@@ -1,0 +1,3 @@
+export function foo() {
+  return 'foo'
+}

--- a/packages/integrate-module/src/index.ts
+++ b/packages/integrate-module/src/index.ts
@@ -6,6 +6,7 @@ import { supportedExtensions } from 'file-type'
 
 import { foo } from './foo.mjs'
 import { bar } from './subdirectory/bar.mjs'
+import { baz } from './subdirectory/index.mjs'
 
 await test('file-type should work', () => {
   assert.ok(supportedExtensions.has('jpg'))
@@ -17,4 +18,8 @@ await test('resolve adjacent file path', () => {
 
 await test('resolve nested file path', () => {
   assert.equal(bar(), 'bar')
+})
+
+await test('resolve nested entry point', () => {
+  assert.equal(baz(), 'baz')
 })

--- a/packages/integrate-module/src/index.ts
+++ b/packages/integrate-module/src/index.ts
@@ -4,6 +4,17 @@ import test from 'node:test'
 
 import { supportedExtensions } from 'file-type'
 
+import { foo } from './foo.mjs'
+import { bar } from './subdirectory/bar.mjs'
+
 await test('file-type should work', () => {
   assert.ok(supportedExtensions.has('jpg'))
+})
+
+await test('resolve adjacent file path', () => {
+  assert.equal(foo(), 'foo')
+})
+
+await test('resolve nested file path', () => {
+  assert.equal(bar(), 'bar')
 })

--- a/packages/integrate-module/src/subdirectory/bar.mts
+++ b/packages/integrate-module/src/subdirectory/bar.mts
@@ -1,0 +1,3 @@
+export function bar() {
+  return 'bar'
+}

--- a/packages/integrate-module/src/subdirectory/baz.mts
+++ b/packages/integrate-module/src/subdirectory/baz.mts
@@ -1,0 +1,3 @@
+export function baz() {
+  return 'baz'
+}

--- a/packages/integrate-module/src/subdirectory/index.mts
+++ b/packages/integrate-module/src/subdirectory/index.mts
@@ -1,3 +1,4 @@
+export { baz } from './baz.mjs'
 export function module() {
   return 'module'
 }

--- a/packages/integrate-module/src/subdirectory/index.mts
+++ b/packages/integrate-module/src/subdirectory/index.mts
@@ -1,0 +1,3 @@
+export function module() {
+  return 'module'
+}

--- a/packages/register/esm.mts
+++ b/packages/register/esm.mts
@@ -20,7 +20,7 @@ const DEFAULT_EXTENSIONS = ['.ts', '.tsx', '.mts', '.cts']
 const TRANSFORM_MAP = new Map<string, string>()
 
 async function checkRequestURL(parentURL: string, requestURL: string) {
-  const { ext } = parse(requestURL)
+  const { dir, name, ext } = parse(requestURL)
   const parentDir = join(parentURL.startsWith('file://') ? fileURLToPath(parentURL) : parentURL, '..')
   if (ext && ext !== '.js' && ext !== '.mjs') {
     try {
@@ -33,7 +33,7 @@ async function checkRequestURL(parentURL: string, requestURL: string) {
   } else {
     for (const ext of DEFAULT_EXTENSIONS) {
       try {
-        const url = join(parentDir, requestURL + ext)
+        const url = join(parentDir, dir, `${name}${ext}`)
         await fs.access(url, FSConstants.R_OK)
         return url
       } catch (e) {
@@ -59,7 +59,7 @@ export const resolve: ResolveFn = async (specifier, context, nextResolve) => {
   if (parentURL && TRANSFORM_MAP.has(parentURL) && specifier.startsWith('.')) {
     const existedURL = await checkRequestURL(parentURL, specifier)
     if (existedURL) {
-      const url = `${existedURL}.mjs`
+      const { href: url } = pathToFileURL(existedURL)
       TRANSFORM_MAP.set(url, existedURL)
       return {
         url: new URL(url).href,


### PR DESCRIPTION
The current `register/esm` does not resolve relative file path correctly.
For example, the following code and command doesn't run properly.

code
```js
// index.mts
import './foo.mjs'

foo()
```

command
`node --loader @swc-node/register/esm index.mts`

and the error
```
Error [ERR_MODULE_NOT_FOUND]: Cannot find module '/path/to/foo.mjs' imported from /path/to/index.mts.mjs
```

This PR fixes the problem.
