### PR TITLE
fix: tsCompilerOptionsToSwcConfig should not override default swc config for jest

### DIFF
--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -20,6 +20,7 @@ export interface Options {
   dynamicImport?: boolean
   esModuleInterop?: boolean
   keepClassNames?: boolean
+  externalHelpers?: boolean
   react?: Partial<ReactConfig>
   paths?: {
     [from: string]: [string]
@@ -36,7 +37,7 @@ function transformOption(path: string, options?: Options, jest = false): SwcOpti
       ? undefined
       : {
           target: opts.target ?? DEFAULT_ES_TARGET,
-          externalHelpers: jest ? true : false,
+          externalHelpers: jest ? true : Boolean(opts.externalHelpers),
           parser: {
             syntax: 'typescript' as const,
             tsx: typeof opts.jsx !== 'undefined' ? opts.jsx : path.endsWith('.tsx'),

--- a/packages/jest/__test__/hoist-top-level.spec.ts
+++ b/packages/jest/__test__/hoist-top-level.spec.ts
@@ -1,5 +1,6 @@
-import { transformJest } from '@swc-node/core'
 import test from 'ava'
+
+const { process } = require('../index')
 
 const BrorrwFromTsJest = `
 const foo = 'foo'
@@ -36,6 +37,8 @@ const func2 = () => {
 `
 
 test('should hoist top level jest mock call', (t) => {
-  const { code } = transformJest(BrorrwFromTsJest, 'jest.spec.ts', { target: 'es2018', sourcemap: false })
+  const { code } = process(BrorrwFromTsJest, 'jest.spec.ts', {
+    transformerConfig: { target: 'es2018', sourcemap: false },
+  })
   t.snapshot(code)
 })

--- a/packages/register/__test__/ts-compiler-options-to-swc-config.spec.ts
+++ b/packages/register/__test__/ts-compiler-options-to-swc-config.spec.ts
@@ -15,27 +15,16 @@ test('default values', (t) => {
     experimentalDecorators: false,
     emitDecoratorMetadata: false,
     esModuleInterop: false,
+    dynamicImport: true,
+    externalHelpers: false,
+    jsx: true,
+    paths: {},
+    keepClassNames: true,
+    target: 'es2018',
+    react: undefined,
     swc: {
-      filename,
       inputSourceMap: undefined,
       sourceRoot: undefined,
-      jsc: {
-        externalHelpers: false,
-        parser: {
-          syntax: 'typescript',
-          tsx: true,
-          dynamicImport: true,
-          decorators: undefined,
-        },
-        paths: {},
-        keepClassNames: true,
-        target: 'es2018',
-        transform: {
-          decoratorMetadata: undefined,
-          legacyDecorator: undefined,
-          react: undefined,
-        },
-      },
     },
   }
   t.deepEqual(swcConfig, expected)
@@ -51,18 +40,6 @@ test('should set the decorator config', (t) => {
   const expected = {
     experimentalDecorators: true,
     emitDecoratorMetadata: true,
-    swc: {
-      filename,
-      jsc: {
-        parser: {
-          decorators: true,
-        },
-        transform: {
-          decoratorMetadata: true,
-          legacyDecorator: true,
-        },
-      },
-    },
   }
   t.like(swcConfig, expected)
 })
@@ -75,22 +52,17 @@ test('should force the jsx  config', (t) => {
   const swcConfig = tsCompilerOptionsToSwcConfig(options, filename)
   const expected = {
     module: 'es6',
+    jsx: true,
+    react: {
+      pragma: options.jsxFactory,
+      pragmaFrag: options.jsxFragmentFactory,
+      importSource: 'react',
+      runtime: 'automatic',
+      useBuiltins: true,
+    },
     swc: {
-      filename,
-      jsc: {
-        parser: {
-          tsx: true,
-        },
-        transform: {
-          react: {
-            pragma: options.jsxFactory,
-            pragmaFrag: options.jsxFragmentFactory,
-            importSource: 'react',
-            runtime: 'automatic',
-            useBuiltins: true,
-          },
-        },
-      },
+      inputSourceMap: undefined,
+      sourceRoot: undefined,
     },
   }
   t.like(swcConfig, expected)
@@ -122,39 +94,28 @@ test('should set all values', (t) => {
   const expected = {
     module: 'commonjs',
     sourcemap: 'inline',
+    target: 'es5',
     experimentalDecorators: options.experimentalDecorators,
     emitDecoratorMetadata: options.emitDecoratorMetadata,
     esModuleInterop: options.esModuleInterop,
+    externalHelpers: true,
+    dynamicImport: true,
+    keepClassNames: true,
+    jsx: true,
+    react: {
+      pragma: options.jsxFactory,
+      pragmaFrag: options.jsxFragmentFactory,
+      importSource: options.jsxImportSource,
+      runtime: 'classic',
+      useBuiltins: true,
+    },
+    paths: {
+      '@test': [join(__dirname, './specific-path-1/test')],
+      '@another': [join(__dirname, './specific-path-2/another')],
+    },
     swc: {
-      filename,
       inputSourceMap: options.inlineSourceMap,
       sourceRoot: options.sourceRoot,
-      jsc: {
-        externalHelpers: options.importHelpers,
-        parser: {
-          syntax: 'typescript',
-          tsx: true,
-          dynamicImport: true,
-          decorators: options.experimentalDecorators,
-        },
-        paths: {
-          '@test': [join(__dirname, './specific-path-1/test')],
-          '@another': [join(__dirname, './specific-path-2/another')],
-        },
-        keepClassNames: true,
-        target: 'es5',
-        transform: {
-          decoratorMetadata: options.emitDecoratorMetadata,
-          legacyDecorator: options.experimentalDecorators,
-          react: {
-            pragma: options.jsxFactory,
-            pragmaFrag: options.jsxFragmentFactory,
-            importSource: options.jsxImportSource,
-            runtime: 'classic',
-            useBuiltins: true,
-          },
-        },
-      },
     },
   }
   t.deepEqual(swcConfig, expected)


### PR DESCRIPTION
fix for #700 #713 