### PR TITLE
fix(register): respect SWCRC environment variable when running in async mode

### DIFF
--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -58,10 +58,12 @@ function transformOption(path: string, options?: Options, jest = false): SwcOpti
         },
     minify: false,
     isModule: true,
-    module: {
-      type: options?.module ?? 'commonjs',
-      noInterop: !opts.esModuleInterop,
-    },
+    module: options?.swc?.swcrc
+      ? undefined 
+      : {
+        type: options?.module ?? 'commonjs',
+        noInterop: !opts.esModuleInterop,
+      },
     sourceMaps: jest || typeof opts.sourcemap === 'undefined' ? 'inline' : opts.sourcemap,
     inlineSourcesContent: true,
     swcrc: false,

--- a/packages/register/register.ts
+++ b/packages/register/register.ts
@@ -83,22 +83,25 @@ export function compile(
       compilerOptions: options,
     })
     return injectInlineSourceMap({ filename, code: outputText, map: sourceMapText })
-  } else if (async) {
-    return transform(sourcecode, filename, tsCompilerOptionsToSwcConfig(options, filename)).then(({ code, map }) => {
+  }
+
+  let swcRegisterConfig: Options
+  if (process.env.SWCRC) {
+    // when SWCRC environment variable is set to true it will use swcrc file
+    swcRegisterConfig = {
+      swc: {
+        swcrc: true,
+      },
+    }
+  } else {
+    swcRegisterConfig = tsCompilerOptionsToSwcConfig(options, filename)
+  }
+  
+  if (async) {
+    return transform(sourcecode, filename, swcRegisterConfig).then(({ code, map }) => {
       return injectInlineSourceMap({ filename, code, map })
     })
   } else {
-    let swcRegisterConfig: Options
-    if (process.env.SWCRC) {
-      // when SWCRC environment variable is set to true it will use swcrc file
-      swcRegisterConfig = {
-        swc: {
-          swcrc: true,
-        },
-      }
-    } else {
-      swcRegisterConfig = tsCompilerOptionsToSwcConfig(options, filename)
-    }
     const { code, map } = transformSync(sourcecode, filename, swcRegisterConfig)
     return injectInlineSourceMap({ filename, code, map })
   }


### PR DESCRIPTION
The current `@swc-node/register/esm` loader does not respect the `SWCRC` environment variable. This is due to the condition for setting `swcRegisterConfig` only applying to the sync `transform` version.

This PR fixes that, and also fixes `module` being overridden by `"commonjs"` when `SWCRC` environment variable is specified, which causes files being transformed by `register/esm` to be loaded as CommonJS which causes errors such as these:

```
server  | file:///app/apps/backend/src/app.ts:2
server  | Object.defineProperty(exports, "__esModule", {
server  |                       ^
server  |
server  | ReferenceError: exports is not defined in ES module scope
server  |     at file:///app/apps/backend/src/app.ts.mjs:2:23
server  |     at ModuleJob.run (node:internal/modules/esm/module_job:194:25)
server  |
```