### PR TITLE
fix: fix import absolute path support

### DIFF
--- a/packages/register/esm.mts
+++ b/packages/register/esm.mts
@@ -69,6 +69,7 @@ export const resolve: ResolveFn = async (specifier, context, nextResolve) => {
     }
   }
   if (DEFAULT_EXTENSIONS.some((ext) => specifier.endsWith(ext))) {
+    specifier = specifier.startsWith('file://') ? specifier : pathToFileURL(specifier).toString()
     const newUrl = `${specifier}.mjs`
     TRANSFORM_MAP.set(newUrl, fileURLToPath(specifier))
     return {


### PR DESCRIPTION
currently when import with absolute path, error shows:

```
node:internal/errors:496
    ErrorCaptureStackTrace(err);
    ^

TypeError [ERR_INVALID_URL]: Invalid URL
    at new NodeError (node:internal/errors:405:5)
    at new URL (node:internal/url:611:13)
    at fileURLToPath (node:internal/url:1399:12)
    at resolve (file:///xxx/node_modules/@swc-node/register/esm/esm.mjs:66:35)
    at nextResolve (node:internal/modules/esm/loader:163:28)
    at ESMLoader.resolve (node:internal/modules/esm/loader:835:30)
    at ESMLoader.getModuleJob (node:internal/modules/esm/loader:424:18)
    at ESMLoader.import (node:internal/modules/esm/loader:524:22)
    at importModuleDynamically (node:internal/modules/esm/translators:110:35)
    at importModuleDynamicallyCallback (node:internal/process/esm_loader:35:14) {
  input: '/Volumes/test/10_client.ts',
  code: 'ERR_INVALID_URL'
}
```