### PR TITLE
fix(core): assign `baseUrl` property

### DIFF
--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -56,6 +56,7 @@ function transformOption(path: string, options?: Options, jest = false): SwcOpti
           },
           keepClassNames: opts.keepClassNames,
           paths: opts.paths,
+          baseUrl: opts.baseUrl,
         },
     minify: false,
     isModule: true,


### PR DESCRIPTION
#721 did declare `baseUrl` property, but did not assign that.

This PR fixes it to fix problems something like:
`failed to handle: base_dir() must be absolute. Please ensure that jsc.baseUrl is specified correctly.`
