### PR TITLE
Fix #716

### DIFF
--- a/packages/register/register.ts
+++ b/packages/register/register.ts
@@ -108,8 +108,8 @@ export function compile(
 }
 
 export function register(options: Partial<ts.CompilerOptions> = {}, hookOpts = {}) {
-  if (!process.env.SWCRC) {
-    options = readDefaultTsConfig()
+  if (!process.env.SWCRC) { 
+    options = Object.keys(options).length ? options : readDefaultTsConfig() 
   }
   options.module = ts.ModuleKind.CommonJS
   installSourceMapSupport()


### PR DESCRIPTION
Fixes #716

Use the provided options passed to `register` if `process.env.SWCRC` is missing rather than always calling `readDefaultTsConfig()`.