### PR TITLE
Mention --enable-source-maps in README.md for esm projects.

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ node --import @swc-node/register/esm-register script.ts # for esm project with n
 node --loader @swc-node/register/esm script.ts # for esm project with node<=20.5, deprecated
 ```
 
+Pass `--enable-source-maps` to node for esm projects
+
 Set environment variable SWCRC=true when you would like to load .swcrc file
 
 ```bash


### PR DESCRIPTION
`@swc-node/sourcemap-support` only works on cjs projects. The underlying library `source-map-support` is more than 2 years old and doesn't seem to work with native esm.

Ask people to use Node's built-in source map support. Although experimental, it works well in my very minimal setup.

Related issue: https://github.com/swc-project/swc-node/issues/719