### PR TITLE
fix(core): respect sourceMaps swcrc value

### DIFF
--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -71,7 +71,11 @@ function transformOption(path: string, options?: Options, jest = false): SwcOpti
               }
             : undefined),
         },
-    sourceMaps: jest || typeof opts.sourcemap === 'undefined' ? 'inline' : opts.sourcemap,
+    sourceMaps: options?.swc?.swcrc
+      ? undefined
+      : jest || typeof opts.sourcemap === 'undefined'
+      ? 'inline'
+      : opts.sourcemap,
     inlineSourcesContent: true,
     swcrc: false,
     ...(options?.swc ?? {}),


### PR DESCRIPTION
Fixes #741

When using a `.swcrc` file, the `sourceMaps` setting is ignored and always set as `"inline"` in the SWC config.

This PR fixes the issue by leaving `sourceMaps` undefined in the SWC config, so that the value from the `.swcrc` file takes effect.