### PR TITLE
fix: fix import ts from node_modules

### DIFF
--- a/packages/register/esm.mts
+++ b/packages/register/esm.mts
@@ -34,17 +34,19 @@ const host: ts.ModuleResolutionHost = {
 const EXTENSIONS: string[] = [ts.Extension.Ts, ts.Extension.Tsx, ts.Extension.Mts]
 
 export const resolve: ResolveFn = async (specifier, context, nextResolve) => {
+  const isTS = EXTENSIONS.some((ext) => specifier.endsWith(ext))
+
   // entrypoint
   if (!context.parentURL) {
     return {
-      format: EXTENSIONS.some((ext) => specifier.endsWith(ext)) ? 'ts' : undefined,
+      format: isTS ? 'ts' : undefined,
       url: specifier,
       shortCircuit: true,
     }
   }
 
   // import/require from external library
-  if (context.parentURL.includes('/node_modules/')) {
+  if (context.parentURL.includes('/node_modules/') && !isTS) {
     return nextResolve(specifier)
   }
 


### PR DESCRIPTION
as https://github.com/swc-project/swc-node/pull/727#pullrequestreview-1760882920 describes, when import `.ts` files from node_moduels, it throws error `TypeError [ERR_UNKNOWN_FILE_EXTENSION]: Unknown file extension ".ts"`.

it works well in 1.6.7

example scene: monorepo import .ts file in project,  or server framework wants dynamic load routes in development