### PR TITLE
feat(core): support swc's `ignoreDynamic` option

### DIFF
--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -28,6 +28,7 @@ export interface Options {
     [from: string]: [string]
   }
   swc?: SwcOptions
+  ignoreDynamic?: boolean
 }
 
 function transformOption(path: string, options?: Options, jest = false): SwcOptions {
@@ -70,6 +71,7 @@ function transformOption(path: string, options?: Options, jest = false): SwcOpti
           ...(moduleType === 'commonjs' || moduleType === 'umd' || moduleType === 'amd'
             ? {
                 noInterop: !opts.esModuleInterop,
+                ignoreDynamic: opts.ignoreDynamic,
               }
             : undefined),
         },

--- a/packages/register/read-default-tsconfig.ts
+++ b/packages/register/read-default-tsconfig.ts
@@ -137,6 +137,7 @@ export function tsCompilerOptionsToSwcConfig(options: ts.CompilerOptions, filena
         ((aliasPaths as string[]) ?? []).map((path) => resolve(options.baseUrl ?? './', path)),
       ]),
     ) as Options['paths'],
+    ignoreDynamic: Boolean(process.env.SWC_NODE_IGNORE_DYNAMIC),
     swc: {
       sourceRoot: options.sourceRoot,
       inputSourceMap: options.inlineSourceMap,


### PR DESCRIPTION
Add the `ignoreDynamic` option to the `@swc-node/core`, and the `SWC_NODE_IGNORE_DYNAMIC` env option.

----

Given the following the CLI written in TypeScript:

```ts
#!/usr/bin/env node

import { arg } from 'arg'

async function main() {
  // some CLI stuff
  // ...

  arg();

  const { method } = await import('some-pure-esm-module');

  // other stuff
}

main().catch(exit)
```

SWC emits the following output when transpiling it into CommonJ,:

```js
#!/usr/bin/env node
"use strict";
Object.defineProperty(exports, "__esModule", {
    value: true
});
const _arg = require("arg");
function _getRequireWildcardCache(nodeInterop) {
    if (typeof WeakMap !== "function") return null;
    var cacheBabelInterop = new WeakMap();
    var cacheNodeInterop = new WeakMap();
    return (_getRequireWildcardCache = function(nodeInterop) {
        return nodeInterop? cacheNodeInterop : cacheBabelInterop;
    })(nodeInterop);
}
function _interop_require_wildcard(obj, nodeInterop) {
    if (!nodeInterop && obj && obj.__esModule) {
        return obj;
    }
    if (obj === null || typeof obj !== "object" && typeof obj !== "function") {
        return {
            default: obj
        };
    }
    var cache = _getRequireWildcardCache(nodeInterop);
    if (cache && cache.has(obj)) {
        return cache.get(obj);
    }
    var newObj = {
        __proto__: null
    };
    var hasPropertyDescriptor = Object.defineProperty && Object.getOwnPropertyDescriptor;
    for(var key in obj){
        if (key !== "default" && Object.prototype.hasOwnProperty.call(obj, key)) {
            var desc = hasPropertyDescriptor ? Object.getOwnPropertyDescriptor(obj, key) : null;
            if (desc && (desc.get || desc.set)) {
                Object.defineProperty(newObj, key, desc);
            } else {
                newObj[key] = obj[key];
            }
        }
    }
    newObj.default = obj;
    if (cache) {
        cache.set(obj, newObj);
    }
    return newObj;
}
async function main() {
    (0, _arg.arg)();
    const { method } = await Promise.resolve().then(()=>_interop_require_wildcard(require("some-pure-esm-module")));
}
main().catch(exit);
```

Notice that the `import { arg } from 'arg'` is transformed into `const _arg = require("arg");`, but the `await import('some-pure-esm-module')` is transformed into `await Promise.resolve().then(()=>_interop_require_wildcard(require("some-pure-esm-module")))`.

The SWC does provide an option to keep transforming `import { arg } from 'arg'` is transformed into `const _arg = require("arg");` while retaining the `await import('some-pure-esm-module')`: [`module.ignoreDynamic`](https://swc.rs/docs/configuration/modules#ignoredynamic). This option is handy when writing Node.js CLI with TypeScript.

The PR adds the `ignoreDynamic` option support for the `swc-node`:

```bash
SWC_NODE_IGNORE_DYNAMIC=true node -r @swc-node/register src/bin/index.ts
```

-----

I want to make `options.ignoreDynamic` enabled by default in `@swc-node/register`, but I am afraid this could introduce a breaking change. Thus I add `SWC_NODE_IGNORE_DYNAMIC=true`.