### PR TITLE
feat: add esm-register for node>20.6

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -162,6 +162,9 @@ dist
 #/target
 Cargo.lock
 
+# idea
+.idea/
+
 *.node
 lib
 artifacts

--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@ Run TypeScript with node, without compilation or typechecking:
 ```bash
 npm i -D @swc-node/register
 node -r @swc-node/register script.ts
-node --loader @swc-node/register/esm script.ts # for esm project
+node --import @swc-node/register/esm-register script.ts # for esm project with node>=20.6
+node --loader @swc-node/register/esm script.ts # for esm project with node<=20.5, deprecated
 ```
 
 Set environment variable SWCRC=true when you would like to load .swcrc file
@@ -25,6 +26,14 @@ Set environment variable SWCRC=true when you would like to load .swcrc file
 ```bash
 SWCRC=true node -r @swc-node/register script.ts
 ```
+
+```typescript
+#!/usr/bin/env node --import swc-register-esm
+
+// your code
+```
+
+run with shebang, add `TS_NODE_PROJECT=null`(`#!/usr/bin/env TS_NODE_PROJECT=null node --import swc-register-esm`) to use ignore tsconfig.json
 
 ## @swc-node/core
 

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@types/babel__core": "^7.20.1",
     "@types/benchmark": "^2.1.2",
     "@types/lodash": "^4.14.197",
-    "@types/node": "^20.5.0",
+    "@types/node": "^20.11.0",
     "@types/sinon": "^10.0.16",
     "@typescript-eslint/eslint-plugin": "^6.4.0",
     "@typescript-eslint/parser": "^6.4.0",

--- a/packages/register/esm-register.mts
+++ b/packages/register/esm-register.mts
@@ -1,0 +1,4 @@
+import { register } from 'node:module'
+import { pathToFileURL } from 'node:url'
+
+register('@swc-node/register/esm', pathToFileURL('./').toString())

--- a/packages/register/package.json
+++ b/packages/register/package.json
@@ -75,6 +75,9 @@
     },
     "./esm": {
       "import": "./esm/esm.mjs"
+    },
+    "./esm-register": {
+      "import": "./esm/esm-register.mjs"
     }
   }
 }

--- a/packages/register/tsconfig.esm.json
+++ b/packages/register/tsconfig.esm.json
@@ -5,5 +5,5 @@
     "outDir": "esm"
   },
   "include": [],
-  "files": ["./esm.mts", "register.d.ts", "./read-default-tsconfig.d.ts"]
+  "files": ["./esm.mts", "./esm-register.mts", "register.d.ts", "./read-default-tsconfig.d.ts"]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39,8 +39,8 @@ importers:
         specifier: ^4.14.197
         version: 4.14.197
       '@types/node':
-        specifier: ^20.5.0
-        version: 20.5.0
+        specifier: ^20.11.0
+        version: 20.11.0
       '@types/sinon':
         specifier: ^10.0.16
         version: 10.0.16
@@ -82,7 +82,7 @@ importers:
         version: 8.0.3
       jest:
         specifier: ^29.6.2
-        version: 29.6.2(@types/node@20.5.0)
+        version: 29.6.2(@types/node@20.11.0)
       lerna:
         specifier: ^7.1.5
         version: 7.1.5(@swc-node/register@packages+register)
@@ -136,7 +136,7 @@ importers:
         version: 18.0.11
       jest:
         specifier: ^29.5.0
-        version: 29.6.2(@types/node@20.5.0)
+        version: 29.6.2(@types/node@20.11.0)
       react:
         specifier: ^18.2.0
         version: 18.2.0
@@ -1851,7 +1851,7 @@ packages:
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
       '@jest/types': 29.6.1
-      '@types/node': 20.5.0
+      '@types/node': 20.11.0
       chalk: 4.1.2
       jest-message-util: 29.6.2
       jest-util: 29.6.2
@@ -1872,14 +1872,14 @@ packages:
       '@jest/test-result': 29.6.2
       '@jest/transform': 29.6.2
       '@jest/types': 29.6.1
-      '@types/node': 20.5.0
+      '@types/node': 20.11.0
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       ci-info: 3.8.0
       exit: 0.1.2
       graceful-fs: 4.2.11
       jest-changed-files: 29.5.0
-      jest-config: 29.6.2(@types/node@20.5.0)
+      jest-config: 29.6.2(@types/node@20.11.0)
       jest-haste-map: 29.6.2
       jest-message-util: 29.6.2
       jest-regex-util: 29.4.3
@@ -1907,7 +1907,7 @@ packages:
     dependencies:
       '@jest/fake-timers': 29.6.2
       '@jest/types': 29.6.1
-      '@types/node': 20.5.0
+      '@types/node': 20.11.0
       jest-mock: 29.6.2
     dev: true
 
@@ -1934,7 +1934,7 @@ packages:
     dependencies:
       '@jest/types': 29.6.1
       '@sinonjs/fake-timers': 10.3.0
-      '@types/node': 20.5.0
+      '@types/node': 20.11.0
       jest-message-util: 29.6.2
       jest-mock: 29.6.2
       jest-util: 29.6.2
@@ -1967,7 +1967,7 @@ packages:
       '@jest/transform': 29.6.2
       '@jest/types': 29.6.1
       '@jridgewell/trace-mapping': 0.3.18
-      '@types/node': 20.5.0
+      '@types/node': 20.11.0
       chalk: 4.1.2
       collect-v8-coverage: 1.0.1
       exit: 0.1.2
@@ -2055,7 +2055,7 @@ packages:
       '@jest/schemas': 29.6.0
       '@types/istanbul-lib-coverage': 2.0.4
       '@types/istanbul-reports': 3.0.1
-      '@types/node': 20.5.0
+      '@types/node': 20.11.0
       '@types/yargs': 17.0.24
       chalk: 4.1.2
     dev: true
@@ -2973,7 +2973,7 @@ packages:
   /@types/graceful-fs@4.1.6:
     resolution: {integrity: sha512-Sig0SNORX9fdW+bQuTEovKj3uHcUL6LQKbCrrqb1X7J6/ReAbhCXRAhc+SMejhLELFj2QcyuxmUooZ4bt5ReSw==}
     dependencies:
-      '@types/node': 20.5.0
+      '@types/node': 20.11.0
     dev: true
 
   /@types/istanbul-lib-coverage@2.0.4:
@@ -3023,8 +3023,10 @@ packages:
     resolution: {integrity: sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA==}
     dev: true
 
-  /@types/node@20.5.0:
-    resolution: {integrity: sha512-Mgq7eCtoTjT89FqNoTzzXg2XvCi5VMhRV6+I2aYanc6kQCBImeNaAYRs/DyoVqk1YEUJK5gN9VO7HRIdz4Wo3Q==}
+  /@types/node@20.11.0:
+    resolution: {integrity: sha512-o9bjXmDNcF7GbM4CNQpmi+TutCgap/K3w1JyKgxAjqx41zp9qlIAVFi0IhCNsJcXolEqLWhbFbEeL0PvYm4pcQ==}
+    dependencies:
+      undici-types: 5.26.5
     dev: true
 
   /@types/normalize-package-data@2.4.1:
@@ -5118,7 +5120,7 @@ packages:
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
       '@jest/expect-utils': 29.6.2
-      '@types/node': 20.5.0
+      '@types/node': 20.11.0
       jest-get-type: 29.4.3
       jest-matcher-utils: 29.6.2
       jest-message-util: 29.6.2
@@ -6255,7 +6257,7 @@ packages:
       '@jest/expect': 29.6.2
       '@jest/test-result': 29.6.2
       '@jest/types': 29.6.1
-      '@types/node': 20.5.0
+      '@types/node': 20.11.0
       chalk: 4.1.2
       co: 4.6.0
       dedent: 1.5.1
@@ -6276,7 +6278,7 @@ packages:
       - supports-color
     dev: true
 
-  /jest-cli@29.6.2(@types/node@20.5.0):
+  /jest-cli@29.6.2(@types/node@20.11.0):
     resolution: {integrity: sha512-TT6O247v6dCEX2UGHGyflMpxhnrL0DNqP2fRTKYm3nJJpCTfXX3GCMQPGFjXDoj0i5/Blp3jriKXFgdfmbYB6Q==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     hasBin: true
@@ -6293,7 +6295,7 @@ packages:
       exit: 0.1.2
       graceful-fs: 4.2.11
       import-local: 3.1.0
-      jest-config: 29.6.2(@types/node@20.5.0)
+      jest-config: 29.6.2(@types/node@20.11.0)
       jest-util: 29.6.2
       jest-validate: 29.6.2
       prompts: 2.4.2
@@ -6305,7 +6307,7 @@ packages:
       - ts-node
     dev: true
 
-  /jest-config@29.6.2(@types/node@20.5.0):
+  /jest-config@29.6.2(@types/node@20.11.0):
     resolution: {integrity: sha512-VxwFOC8gkiJbuodG9CPtMRjBUNZEHxwfQXmIudSTzFWxaci3Qub1ddTRbFNQlD/zUeaifLndh/eDccFX4wCMQw==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     peerDependencies:
@@ -6320,7 +6322,7 @@ packages:
       '@babel/core': 7.22.10
       '@jest/test-sequencer': 29.6.2
       '@jest/types': 29.6.1
-      '@types/node': 20.5.0
+      '@types/node': 20.11.0
       babel-jest: 29.6.2(@babel/core@7.22.10)
       chalk: 4.1.2
       ci-info: 3.8.0
@@ -6380,7 +6382,7 @@ packages:
       '@jest/environment': 29.6.2
       '@jest/fake-timers': 29.6.2
       '@jest/types': 29.6.1
-      '@types/node': 20.5.0
+      '@types/node': 20.11.0
       jest-mock: 29.6.2
       jest-util: 29.6.2
     dev: true
@@ -6396,7 +6398,7 @@ packages:
     dependencies:
       '@jest/types': 29.6.1
       '@types/graceful-fs': 4.1.6
-      '@types/node': 20.5.0
+      '@types/node': 20.11.0
       anymatch: 3.1.3
       fb-watchman: 2.0.2
       graceful-fs: 4.2.11
@@ -6447,7 +6449,7 @@ packages:
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
       '@jest/types': 29.6.1
-      '@types/node': 20.5.0
+      '@types/node': 20.11.0
       jest-util: 29.6.2
     dev: true
 
@@ -6502,7 +6504,7 @@ packages:
       '@jest/test-result': 29.6.2
       '@jest/transform': 29.6.2
       '@jest/types': 29.6.1
-      '@types/node': 20.5.0
+      '@types/node': 20.11.0
       chalk: 4.1.2
       emittery: 0.13.1
       graceful-fs: 4.2.11
@@ -6533,7 +6535,7 @@ packages:
       '@jest/test-result': 29.6.2
       '@jest/transform': 29.6.2
       '@jest/types': 29.6.1
-      '@types/node': 20.5.0
+      '@types/node': 20.11.0
       chalk: 4.1.2
       cjs-module-lexer: 1.2.2
       collect-v8-coverage: 1.0.1
@@ -6585,7 +6587,7 @@ packages:
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
       '@jest/types': 29.6.1
-      '@types/node': 20.5.0
+      '@types/node': 20.11.0
       chalk: 4.1.2
       ci-info: 3.8.0
       graceful-fs: 4.2.11
@@ -6610,7 +6612,7 @@ packages:
     dependencies:
       '@jest/test-result': 29.6.2
       '@jest/types': 29.6.1
-      '@types/node': 20.5.0
+      '@types/node': 20.11.0
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       emittery: 0.13.1
@@ -6622,7 +6624,7 @@ packages:
     resolution: {integrity: sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==}
     engines: {node: '>= 10.13.0'}
     dependencies:
-      '@types/node': 20.5.0
+      '@types/node': 20.11.0
       merge-stream: 2.0.0
       supports-color: 8.1.1
     dev: true
@@ -6631,13 +6633,13 @@ packages:
     resolution: {integrity: sha512-l3ccBOabTdkng8I/ORCkADz4eSMKejTYv1vB/Z83UiubqhC1oQ5Li6dWCyqOIvSifGjUBxuvxvlm6KGK2DtuAQ==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
-      '@types/node': 20.5.0
+      '@types/node': 20.11.0
       jest-util: 29.6.2
       merge-stream: 2.0.0
       supports-color: 8.1.1
     dev: true
 
-  /jest@29.6.2(@types/node@20.5.0):
+  /jest@29.6.2(@types/node@20.11.0):
     resolution: {integrity: sha512-8eQg2mqFbaP7CwfsTpCxQ+sHzw1WuNWL5UUvjnWP4hx2riGz9fPSzYOaU5q8/GqWn1TfgZIVTqYJygbGbWAANg==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     hasBin: true
@@ -6650,7 +6652,7 @@ packages:
       '@jest/core': 29.6.2
       '@jest/types': 29.6.1
       import-local: 3.1.0
-      jest-cli: 29.6.2(@types/node@20.5.0)
+      jest-cli: 29.6.2(@types/node@20.11.0)
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -9297,6 +9299,10 @@ packages:
       has-bigints: 1.0.2
       has-symbols: 1.0.3
       which-boxed-primitive: 1.0.2
+    dev: true
+
+  /undici-types@5.26.5:
+    resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
     dev: true
 
   /unicode-canonical-property-names-ecmascript@2.0.0:


### PR DESCRIPTION
According to the node.js [release notes](https://nodejs.org/en/blog/release/v20.6.0) for node 20.6 the experimental loaders API was deprecated in favour of the register API.
Because of that, we need to use node --import register.js file.ts instead of node --loader @swc-node/register/esm file.ts.

close #743 