### PR TITLE
fix: esm module resolve issues

### DIFF
--- a/.changeset/spotty-mails-relate.md
+++ b/.changeset/spotty-mails-relate.md
@@ -1,0 +1,5 @@
+---
+"@fake-scope/fake-pkg": patch
+---
+
+fix: convert fileUrl to path before compile, close #753

--- a/.changeset/spotty-mails-relate.md
+++ b/.changeset/spotty-mails-relate.md
@@ -1,5 +1,6 @@
 ---
-"@fake-scope/fake-pkg": patch
+'@fake-scope/fake-pkg': patch
 ---
 
 fix: convert fileUrl to path before compile, close #753
+fix: remove baseUrl from esm to keep module import specifier, cause it use tsc resolver.

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "lint": "eslint -c ./.eslintrc.yml .",
     "test": "ava",
     "test:jest": "jest --config jest.config.js",
-    "test:module": "cross-env SWC_NODE_PROJECT=packages/integrate-module/tsconfig.json node --loader=@swc-node/register/esm packages/integrate-module/src/index.ts",
+    "test:module": "cross-env SWC_NODE_PROJECT=packages/integrate-module/tsconfig.json node --import=@swc-node/register/esm-register packages/integrate-module/src/index.ts",
     "version": "pnpm install && git add .",
     "postinstall": "husky install"
   },

--- a/packages/register/__test__/ts-compiler-options-to-swc-config.spec.ts
+++ b/packages/register/__test__/ts-compiler-options-to-swc-config.spec.ts
@@ -10,7 +10,7 @@ test('default values', (t) => {
   const filename = 'some-file.tsx'
   const swcConfig = tsCompilerOptionsToSwcConfig(options, filename)
   const expected = {
-    baseUrl: process.cwd(),
+    baseUrl: undefined,
     module: 'es6',
     sourcemap: false,
     experimentalDecorators: false,

--- a/packages/register/esm.mts
+++ b/packages/register/esm.mts
@@ -94,7 +94,7 @@ export const load: LoadFn = async (url, context, nextLoad) => {
   if (context.format === 'ts') {
     const { source } = await nextLoad(url, context)
     const code = typeof source === 'string' ? source : Buffer.from(source).toString()
-    const compiled = await compile(code, url, tsconfig, true)
+    const compiled = await compile(code, fileURLToPath(url), tsconfig, true)
     return {
       format: 'module',
       source: compiled,

--- a/packages/register/esm.mts
+++ b/packages/register/esm.mts
@@ -90,11 +90,17 @@ interface LoadResult {
 type LoadArgs = [url: string, context: LoadContext, nextLoad?: (...args: LoadArgs) => Promise<LoadResult>]
 type LoadFn = (...args: Required<LoadArgs>) => Promise<LoadResult>
 
+const tsconfigForSWCNode = {
+  ...tsconfig,
+  paths: undefined,
+  baseUrl: undefined,
+}
+
 export const load: LoadFn = async (url, context, nextLoad) => {
   if (context.format === 'ts') {
     const { source } = await nextLoad(url, context)
     const code = typeof source === 'string' ? source : Buffer.from(source).toString()
-    const compiled = await compile(code, fileURLToPath(url), tsconfig, true)
+    const compiled = await compile(code, fileURLToPath(url), tsconfigForSWCNode, true)
     return {
       format: 'module',
       source: compiled,

--- a/packages/register/read-default-tsconfig.ts
+++ b/packages/register/read-default-tsconfig.ts
@@ -130,7 +130,7 @@ export function tsCompilerOptionsToSwcConfig(options: ts.CompilerOptions, filena
             useBuiltins: true,
           }
         : undefined,
-    baseUrl: resolve(options.baseUrl ?? './'),
+    baseUrl: options.baseUrl ? resolve(options.baseUrl) : undefined,
     paths: Object.fromEntries(
       Object.entries(options.paths ?? {}).map(([aliasKey, aliasPaths]) => [
         aliasKey,


### PR DESCRIPTION
this commit fix some esm module resolve bugs

1. convert fileUrl to path before compile in esm, which may cause path alias resolve issue to align with previous behavior. close #753
2. remove baseUrl from esm to keep module import specifier, as we use tsc resolver. 
