### PR TITLE
only doing file I/O once during webpack loader.

### DIFF
--- a/packages/loader/src/index.ts
+++ b/packages/loader/src/index.ts
@@ -1,7 +1,35 @@
-import { transform } from '@swc-node/core'
+import { transform, Options } from '@swc-node/core'
 import { readDefaultTsConfig, tsCompilerOptionsToSwcConfig } from '@swc-node/register/read-default-tsconfig'
 import { CompilerOptions, convertCompilerOptionsFromJson } from 'typescript'
 import type { LoaderContext } from 'webpack'
+
+let swcConfig: Options
+function getSwcConfig(
+  this: LoaderContext<{
+    compilerOptions?: CompilerOptions
+    configFile?: string
+    fastRefresh?: boolean
+  }>,
+): Options {
+  if (!swcConfig) {
+    const { compilerOptions, configFile, fastRefresh } = this.getOptions() ?? {}
+    const { options: assignedOptions } = convertCompilerOptionsFromJson(compilerOptions, '')
+    const options =
+      !assignedOptions || Object.keys(assignedOptions).length === 0 ? readDefaultTsConfig(configFile) : assignedOptions
+    swcConfig = tsCompilerOptionsToSwcConfig(options, this.resourcePath)
+    if (fastRefresh) {
+      if (swcConfig.react) {
+        swcConfig.react.refresh = true
+      } else {
+        swcConfig.react = {
+          refresh: true,
+        }
+      }
+    }
+  }
+
+  return swcConfig
+}
 
 export function loader(
   this: LoaderContext<{
@@ -12,21 +40,7 @@ export function loader(
   source: string,
 ) {
   const callback = this.async()
-  const { compilerOptions, configFile, fastRefresh } = this.getOptions() ?? {}
-  const { options: assignedOptions } = convertCompilerOptionsFromJson(compilerOptions, '')
-  const options =
-    !assignedOptions || Object.keys(assignedOptions).length === 0 ? readDefaultTsConfig(configFile) : assignedOptions
-  const swcOptions = tsCompilerOptionsToSwcConfig(options, this.resourcePath)
-  if (fastRefresh) {
-    if (swcOptions.react) {
-      swcOptions.react.refresh = true
-    } else {
-      swcOptions.react = {
-        refresh: true,
-      }
-    }
-  }
-  transform(source, this.resourcePath, swcOptions)
+  transform(source, this.resourcePath, getSwcConfig.call(this))
     .then(({ code, map }) => callback(null, code, map))
     .catch((err) => callback(err))
 }


### PR DESCRIPTION
Noticed that this webpack loader takes ~20/30s longer to build then https://www.npmjs.com/package/swc-loader.

this change makes the load time the same in my project when I switch out that loader with this one.