### PR TITLE
fix: add default tsconfig.baseUrl to align with tsc behavior

### DIFF
--- a/.changeset/three-rockets-jump.md
+++ b/.changeset/three-rockets-jump.md
@@ -1,0 +1,5 @@
+---
+"@fake-scope/fake-pkg": patch
+---
+
+fix: add default tsconfig.baseUrl to align with tsc behavior

--- a/packages/register/read-default-tsconfig.ts
+++ b/packages/register/read-default-tsconfig.ts
@@ -34,6 +34,12 @@ export function readDefaultTsConfig(
     const { config } = ts.readConfigFile(fullTsConfigPath, ts.sys.readFile)
 
     const { options, errors, fileNames } = ts.parseJsonConfigFileContent(config, ts.sys, dirname(fullTsConfigPath))
+
+    // if baseUrl not set, use dirname of tsconfig.json. align with ts https://www.typescriptlang.org/tsconfig#paths
+    if (options.paths && !options.baseUrl) {
+      options.baseUrl = dirname(fullTsConfigPath)
+    }
+
     if (!errors.length) {
       compilerOptions = options
       compilerOptions.files = fileNames


### PR DESCRIPTION
In previous pr #754, when `tsconfig.baseUrl` not set, it keeps undefined in swcConfig (to compatible with esm module resolver).

It is a breaking change, case after typescript@4.1 `baseUrl` is an optional value which defaults to dirname of `tsconfig.json`

This pr add a default value to `tsconfig.baseUrl` when `tsconfig.paths` not empty, fixed errors caused by empty `baseUrl` in `tsconfig.json`.
