### PR TITLE
Add a default export to @swc-node/register

### DIFF
--- a/packages/register/register.ts
+++ b/packages/register/register.ts
@@ -118,3 +118,5 @@ export function register(options: Partial<ts.CompilerOptions> = {}, hookOpts = {
     ...hookOpts,
   })
 }
+
+export default register;


### PR DESCRIPTION
### 📝 Description

*First of all is my first contribution here so sorry if I'm opening this issue in a wrong place!*

I would like to **question** / suggest a little change that is add an export default to [this file `packages/register/register.ts`](https://github.com/swc-project/swc-node/blob/master/packages/register/register.ts#L110) to be more specific to this function.

```typescript
// packages/register/register.ts
export function register(options: Partial<ts.CompilerOptions> = {}, hookOpts = {}) { ... }
```

It will be something like that:

```diff
export function register(options: Partial<ts.CompilerOptions> = {}, hookOpts = {}) { ... }
+ export default register;
```

### ✨ Motivation

This is strongly related with these issues:

- [gulpjs/interpret - #98](https://github.com/gulpjs/interpret/issues/98)
- [webpack/webpack-cli - #4129](https://github.com/webpack/webpack-cli/issues/4129)

It is because the previous version [@swc/register](https://www.npmjs.com/package/@swc/register) which now is **deprecated**  used to export it as unamed export so now after upgrade to new version we have to use desconstructing. This is more than expected; it wasn't just a breaking change, the package even changed its name, haha.

```typescript
// Before
const register = require('@swc/register')
```

```typescript
// After
const { register } = require('@swc-node/register')
```

I was going to open a pull request to fix it into [this package](https://github.com/gulpjs/interpret) that is used by **webpack** to fix it when I realized that all these registers use unamed export:

- ts-node/register
- @babel/register
- coffeescript/register
- esbuild-register
- json5/lib/register
- sucrase/register
- @mdx-js/register
- yaml-hook/register

So I belive that can be a good idea follow the pattern. What do you think? Do you see any problems? If I have to make any changes, I'll be happy to do so!