### PR TITLE
fix(register): fix esm entry resolver for third-party executer, close #762

### DIFF
--- a/.changeset/great-goats-trade.md
+++ b/.changeset/great-goats-trade.md
@@ -1,0 +1,5 @@
+---
+"@fake-scope/fake-pkg": patch
+---
+
+fix(register): fix esm entry resolver for third-party executor, close #762

--- a/packages/register/esm.mts
+++ b/packages/register/esm.mts
@@ -11,11 +11,13 @@ interface ResolveContext {
   conditions: string[]
   parentURL: string | undefined
 }
+
 interface ResolveResult {
   format?: string
   shortCircuit?: boolean
   url: string
 }
+
 type ResolveArgs = [
   specifier: string,
   context?: ResolveContext,
@@ -51,7 +53,7 @@ export const resolve: ResolveFn = async (specifier, context, nextResolve) => {
   }
 
   const { resolvedModule } = ts.resolveModuleName(
-    specifier,
+    specifier.endsWith('file:') ? fileURLToPath(specifier) : specifier,
     fileURLToPath(context.parentURL),
     tsconfig,
     host,
@@ -82,11 +84,13 @@ interface LoadContext {
   conditions: string[]
   format: string | null | undefined
 }
+
 interface LoadResult {
   format: string
   shortCircuit?: boolean
   source: string | ArrayBuffer | SharedArrayBuffer | Uint8Array
 }
+
 type LoadArgs = [url: string, context: LoadContext, nextLoad?: (...args: LoadArgs) => Promise<LoadResult>]
 type LoadFn = (...args: Required<LoadArgs>) => Promise<LoadResult>
 

--- a/packages/register/esm.mts
+++ b/packages/register/esm.mts
@@ -53,7 +53,7 @@ export const resolve: ResolveFn = async (specifier, context, nextResolve) => {
   }
 
   const { resolvedModule } = ts.resolveModuleName(
-    specifier.endsWith('file:') ? fileURLToPath(specifier) : specifier,
+    specifier.startsWith('file:') ? fileURLToPath(specifier) : specifier,
     fileURLToPath(context.parentURL),
     tsconfig,
     host,


### PR DESCRIPTION
Third-party executors like mocha, may import scripts with fileUrl absolute path.

This pr converts `specifier` from fileUrl to path.

close #762 