### PR TITLE
fix: fix ts extension detect regexp, close #775 #774 #772

### DIFF
--- a/packages/integrate/__tests__/extention/extention.spec.ts
+++ b/packages/integrate/__tests__/extention/extention.spec.ts
@@ -1,0 +1,38 @@
+import { AVAILABLE_EXTENSION_PATTERN, AVAILABLE_TS_EXTENSION_PATTERN } from '@swc-node/register/register.ts'
+import test from 'ava'
+import * as ts from 'typescript'
+
+const tsExtensions = [ts.Extension.Ts, ts.Extension.Tsx, ts.Extension.Mts, ts.Extension.Cts]
+const nonTsExtensions = [ts.Extension.Js, ts.Extension.Jsx, ts.Extension.Mjs, ts.Extension.Cjs, '.es6', '.es']
+const defaultExtensions = [...tsExtensions, ...nonTsExtensions]
+const ignoreExtensions = ['.txt', '.json', '.xml']
+
+test(`AVAILABLE_TS_EXTENSION_PATTERN matches TypeScript extensions`, (t) => {
+  tsExtensions.forEach((ext) => {
+    t.true(AVAILABLE_TS_EXTENSION_PATTERN.test(`file${ext}`))
+  })
+})
+
+test(`AVAILABLE_TS_EXTENSION_PATTERN does not match d.ts`, (t) => {
+  tsExtensions.forEach((ext) => {
+    t.false(AVAILABLE_TS_EXTENSION_PATTERN.test(`file.d${ext}`))
+  })
+})
+
+test(`AVAILABLE_TS_EXTENSION_PATTERN does not match non-ts extensions`, (t) => {
+  ;[...nonTsExtensions, ...ignoreExtensions].forEach((ext) => {
+    t.false(AVAILABLE_TS_EXTENSION_PATTERN.test(`file${ext}`))
+  })
+})
+
+test(`AVAILABLE_EXTENSION_PATTERN matches default extensions`, (t) => {
+  defaultExtensions.forEach((ext) => {
+    t.true(AVAILABLE_EXTENSION_PATTERN.test(`file${ext}`))
+  })
+})
+
+test(`AVAILABLE_EXTENSION_PATTERN does not match non-default extensions`, (t) => {
+  ignoreExtensions.forEach((ext) => {
+    t.false(AVAILABLE_EXTENSION_PATTERN.test(`file${ext}`))
+  })
+})

--- a/packages/integrate/package.json
+++ b/packages/integrate/package.json
@@ -21,12 +21,14 @@
   "devDependencies": {
     "@swc/helpers": "^0.5.11",
     "@swc-node/core": "^1.13.0",
+    "@swc-node/register": "workspace:*",
     "@types/jest": "^29.5.12",
     "@types/react": "^18.3.1",
     "@types/react-dom": "^18.3.0",
     "jest": "^29.7.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "sinon": "^17.0.1"
+    "sinon": "^17.0.1",
+    "typescript": "^5.4.5"
   }
 }

--- a/packages/integrate/tsconfig.json
+++ b/packages/integrate/tsconfig.json
@@ -6,13 +6,17 @@
     "outDir": "./lib",
     "jsx": "react-jsx",
     "types": ["node", "jest"],
+    "allowImportingTsExtensions": true
   },
   "references": [
     {
-      "path": "../core",
+      "path": "../core"
     },
+    {
+      "path": "../register"
+    }
   ],
   "include": ["."],
   "files": ["./package.json"],
-  "exclude": ["lib"],
+  "exclude": ["lib"]
 }

--- a/packages/register/register.ts
+++ b/packages/register/register.ts
@@ -19,12 +19,12 @@ const DEFAULT_EXTENSIONS = [
 ]
 
 export const AVAILABLE_TS_EXTENSION_PATTERN = new RegExp(
-  `(?<!\\.d(${[ts.Extension.Ts, ts.Extension.Tsx, ts.Extension.Mts, ts.Extension.Cts].map((ext) => ext.replace(/^\./, '\\.')).join('|')}))$`,
+  `((?<!\\.d)(${[ts.Extension.Ts, ts.Extension.Tsx, ts.Extension.Mts, ts.Extension.Cts].map((ext) => ext.replace(/^\./, '\\.')).join('|')}))$`,
   'i',
 )
 
 export const AVAILABLE_EXTENSION_PATTERN = new RegExp(
-  `(?<!\\.d(${DEFAULT_EXTENSIONS.map((ext) => ext.replace(/^\./, '\\.')).join('|')}))$`,
+  `((?<!\\.d)(${DEFAULT_EXTENSIONS.map((ext) => ext.replace(/^\./, '\\.')).join('|')}))$`,
   'i',
 )
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -122,6 +122,9 @@ importers:
       '@swc-node/core':
         specifier: ^1.13.0
         version: link:../core
+      '@swc-node/register':
+        specifier: workspace:*
+        version: link:../register
       '@swc/helpers':
         specifier: ^0.5.11
         version: 0.5.11
@@ -146,6 +149,9 @@ importers:
       sinon:
         specifier: ^17.0.1
         version: 17.0.1
+      typescript:
+        specifier: ^5.4.5
+        version: 5.4.5
 
   packages/integrate-module:
     dependencies:


### PR DESCRIPTION
this issue fixes a bug caused by an invalid regexp, which provides a fast way to detect if the specific file is allowed to transform.

Texts for the case have been added as weel.

fix #775 #774 #772