### PR TITLE
doc: add `@swc/core` dependency to usage example

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 Run TypeScript with node, without compilation or typechecking:
 
 ```bash
-npm i -D @swc-node/register
+npm i -D @swc-node/register @swc/core
 node -r @swc-node/register script.ts
 node --import @swc-node/register/esm-register script.ts # for esm project with node>=20.6
 node --loader @swc-node/register/esm script.ts # for esm project with node<=20.5, deprecated


### PR DESCRIPTION
On a fresh repo, running the previous example would result in a `Error: Cannot find module '@swc/core'` otherwise.

I think it'd also be good to add `@swc/core` as a peer dependency to `@swc-node/register`, so that `@swc/core` will be installed automatically when missing.