### PR TITLE
fix(esm-resolver): only return early if the specifier is an unsupported file

### DIFF
--- a/packages/register/esm.mts
+++ b/packages/register/esm.mts
@@ -18,7 +18,7 @@ const host: ts.ModuleResolutionHost = {
 }
 
 export const resolve: ResolveHook = async (specifier, context, nextResolve) => {
-  if (!AVAILABLE_EXTENSION_PATTERN.test(specifier)) {
+  if (specifier.startsWith('file:') && !AVAILABLE_EXTENSION_PATTERN.test(specifier)) {
     return nextResolve(specifier)
   }
 


### PR DESCRIPTION
Hello,

I encountered an issue with `@swc-node/register@1.9.2` that did not happen with version `1.9.1`

### Description

Pull requests with the issue:
- https://github.com/fargito/rust-cdk-serverless/pull/231
- https://github.com/fargito/event-scout/pull/386

Both projects are esm-only, with Node v20.14.0, running swc with `node --import @swc-node/register/esm-register my-entrypoint.ts`. Also they don't have extensions in the internal imports (i.e. `import  { foo } from './foo'` and not `import { foo } from './foo.js'`).

### Investigation

In #777 the pattern matching for supported extensions, was fixed. It used to match every single string.

However, now that this pattern is correct, the condition used to check it the specifier was supported was no longer valid for extension-less specifiers.

E.g.

```ts
import { foo } from './foo.js'; 
```
Is correctly flagged as a supported specifier and processed by swc.

But:
```ts
import  { foo } from './foo';
```
Isn't flagged as supported, and then directly passed to the default NodeJS loader, which is unable to undestand it.

### Proposed fix

Only apply the early return if the specifier explicitely refers to an unsupported file.

WDYT?