### PR TITLE
fix(register): exclude internal js files from compilation process

### DIFF
--- a/packages/integrate/__tests__/extention/extention.spec.ts
+++ b/packages/integrate/__tests__/extention/extention.spec.ts
@@ -1,10 +1,9 @@
-import { AVAILABLE_EXTENSION_PATTERN, AVAILABLE_TS_EXTENSION_PATTERN } from '@swc-node/register/register.ts'
+import { AVAILABLE_TS_EXTENSION_PATTERN } from '@swc-node/register/register.ts'
 import test from 'ava'
 import * as ts from 'typescript'
 
 const tsExtensions = [ts.Extension.Ts, ts.Extension.Tsx, ts.Extension.Mts, ts.Extension.Cts]
 const nonTsExtensions = [ts.Extension.Js, ts.Extension.Jsx, ts.Extension.Mjs, ts.Extension.Cjs, '.es6', '.es']
-const defaultExtensions = [...tsExtensions, ...nonTsExtensions]
 const ignoreExtensions = ['.txt', '.json', '.xml']
 
 test(`AVAILABLE_TS_EXTENSION_PATTERN matches TypeScript extensions`, (t) => {
@@ -22,17 +21,5 @@ test(`AVAILABLE_TS_EXTENSION_PATTERN does not match d.ts`, (t) => {
 test(`AVAILABLE_TS_EXTENSION_PATTERN does not match non-ts extensions`, (t) => {
   ;[...nonTsExtensions, ...ignoreExtensions].forEach((ext) => {
     t.false(AVAILABLE_TS_EXTENSION_PATTERN.test(`file${ext}`))
-  })
-})
-
-test(`AVAILABLE_EXTENSION_PATTERN matches default extensions`, (t) => {
-  defaultExtensions.forEach((ext) => {
-    t.true(AVAILABLE_EXTENSION_PATTERN.test(`file${ext}`))
-  })
-})
-
-test(`AVAILABLE_EXTENSION_PATTERN does not match non-default extensions`, (t) => {
-  ignoreExtensions.forEach((ext) => {
-    t.false(AVAILABLE_EXTENSION_PATTERN.test(`file${ext}`))
   })
 })

--- a/packages/register/register.ts
+++ b/packages/register/register.ts
@@ -23,11 +23,6 @@ export const AVAILABLE_TS_EXTENSION_PATTERN = new RegExp(
   'i',
 )
 
-export const AVAILABLE_EXTENSION_PATTERN = new RegExp(
-  `((?<!\\.d)(${DEFAULT_EXTENSIONS.map((ext) => ext.replace(/^\./, '\\.')).join('|')}))$`,
-  'i',
-)
-
 const injectInlineSourceMap = ({
   filename,
   code,

--- a/packages/register/register.ts
+++ b/packages/register/register.ts
@@ -89,10 +89,7 @@ export function compile(
   },
   async = false,
 ) {
-  if (
-    (filename.includes('node_modules') && !AVAILABLE_TS_EXTENSION_PATTERN.test(filename)) ||
-    !AVAILABLE_EXTENSION_PATTERN.test(filename)
-  ) {
+  if (!AVAILABLE_TS_EXTENSION_PATTERN.test(filename)) {
     return sourcecode
   }
   if (options && typeof options.fallbackToTs === 'function' && options.fallbackToTs(filename)) {


### PR DESCRIPTION
Hello,

I encountered an issue to upgrade a monorepo to `@swc-node/register` version `1.10.0`. See [the PR](https://github.com/fargito/event-scout/pull/407) and [the workflow run](https://github.com/fargito/event-scout/actions/runs/9725335874/job/26842531668?pr=407).

The issue was that a TS file imported a JS file from within the monorepo (from an internal package).

`@swc-node/register` propertly excluded plain JS file located in the `node_modules` folder from being sent to `swc` for compilation, however, the logic failed when the plain JS file was located outside of `node_modules`.

In my understanding, checking whether a file is located in `node_modules` is irrelevant. What matters is:
- if the file is a ts file, send it to `swc`, then pass the js result to node
- otherwise, return early and let node perform its resolve algorithm

This PR therefore reduces the check. It will only validate that the file is **not** a ts file in order to return early.

Also since I remove the check with the `AVAILABLE_EXTENSION_PATTERN` regex, it became unused so I deleted it. LMK if I should leave it there.