### PR TITLE
fix: loading esm-register via full path from a different cwd

### DIFF
--- a/packages/register/esm-register.mts
+++ b/packages/register/esm-register.mts
@@ -1,4 +1,3 @@
-import { register } from 'node:module'
-import { pathToFileURL } from 'node:url'
+import { register } from 'node:module';
 
-register('@swc-node/register/esm', pathToFileURL('./').toString())
+register('@swc-node/register/esm', import.meta.url)


### PR DESCRIPTION
i.e. using `--import /home/whatever/something/node_modules/@swc-node/register/esm/esm-register.mjs` now should work as well