### PR TITLE
chore: replace deprecated husky install

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "test:jest": "jest --config jest.config.js",
     "test:module": "cross-env SWC_NODE_PROJECT=packages/integrate-module/tsconfig.json node --import=@swc-node/register/esm-register packages/integrate-module/src/index.ts",
     "version": "pnpm install && git add .",
-    "postinstall": "husky install"
+    "postinstall": "husky"
   },
   "devDependencies": {
     "@babel/core": "^7.24.7",


### PR DESCRIPTION
`husky install` -> `husky` (same command)

https://github.com/typicode/husky/releases/tag/v9.0.1