### PR TITLE
docs: recommend `-S` on hashbang

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ SWCRC=true node -r @swc-node/register script.ts
 ```
 
 ```typescript
-#!/usr/bin/env node --import @swc-node/register/esm-register
+#!/usr/bin/env -S node --import @swc-node/register/esm-register
 
 // your code
 ```


### PR DESCRIPTION
The previous hashbang did not work on Linux coreutils `env` because `env` passes the arguments as single string to `node`. By adding `-S` we can make it split the arguments and this works on both GNU coreutils >= 8.30 and BSD `env` (probably since 2005) used on MacOS.

Also see https://github.com/privatenumber/tsx/pull/523 and https://unix.stackexchange.com/a/477651.