### PR TITLE
fix(register): allow running .tsx file

### DIFF
--- a/packages/register/esm.mts
+++ b/packages/register/esm.mts
@@ -42,7 +42,7 @@ const resolver = new ResolverFactory({
   },
   conditionNames: ['node', 'import'],
   enforceExtension: EnforceExtension.Auto,
-  extensions: ['.js', '.mjs', '.cjs', '.ts', 'tsx', '.mts', '.cts', '.json', '.wasm', '.node'],
+  extensions: ['.js', '.mjs', '.cjs', '.ts', '.tsx', '.mts', '.cts', '.json', '.wasm', '.node'],
   extensionAlias: {
     '.js': ['.ts', '.tsx', '.js'],
     '.mjs': ['.mts', '.mjs'],
@@ -138,6 +138,7 @@ const EXTENSION_MODULE_MAP = {
   '.mjs': 'module',
   '.cjs': 'commonjs',
   '.ts': 'module',
+  '.tsx': 'module',
   '.mts': 'module',
   '.cts': 'commonjs',
   '.json': 'json',


### PR DESCRIPTION
Thank you for the fix for #799. Unfortunately I still cannot directly run a .tsx file without the change in this PR. This change makes register/esm consider a .tsx file to be a module like .ts. Also a `.` was missing before `tsx` in an array.