### PR TITLE
fix(register/esm): pass file urls as paths

### DIFF
--- a/packages/register/esm.mts
+++ b/packages/register/esm.mts
@@ -292,7 +292,13 @@ export const load: LoadHook = async (url, context, nextLoad) => {
   debug('loaded', url, resolvedFormat)
 
   const code = !source || typeof source === 'string' ? source : Buffer.from(source).toString()
-  const compiled = await compile(code, url, tsconfigForSWCNode, true)
+
+  // url may be essentially an arbitrary string, but fixing the binding module, which currently
+  // expects a real file path, to correctly interpret this doesn't have an obvious solution,
+  // and would likely be a breaking change anyway. Do a best effort to give a real path
+  // like it expects, which at least fixes relative input sourcemap paths.
+  const filename = url.startsWith('file:') ? fileURLToPath(url) : url
+  const compiled = await compile(code, filename, tsconfigForSWCNode, true)
 
   debug('compiled', url, resolvedFormat)
 


### PR DESCRIPTION
compile() expects a filename, not a url: it passes the value directly to the bindings module, which immediately parses it as a `Path` unconditionally.

This causes input file source maps to fail to load, as it attempts to find the URL as if it were a file on disk. (see https://github.com/swc-project/swc/pull/9422)

This is a targeted fix which hopefully minimizes the chance of things breaking.