### PR TITLE
feat(CLI): Added possibility to have custom config location for swc

### DIFF
--- a/packages/register/register.ts
+++ b/packages/register/register.ts
@@ -97,6 +97,7 @@ export function compile(
     swcRegisterConfig = {
       swc: {
         swcrc: true,
+        configFile: process.env.SWC_CONFIG_FILE
       },
     }
   } else {


### PR DESCRIPTION
We encountered an issue that requires us to specify a custom SWC configuration file when using the `swc-node/register ` package. Our project does not use TypeScript, and we wish to avoid placing irrelevant files like `tsconfig.json` in our root directory. Additionally, we are integrating Jest with `@swc/jest`, which leads to conflicts with the root `.swcrc` file.

To resolve this, we need the ability to specify a custom path for the `.swcrc` file and prevent the root `.swcrc` from being used during real-time node building. The SWC API allows for this through the`configFile` property, which can be implemented similarly to setting `SWCRC=true`.

Our migration process is currently hindered by this limitation, and we've had to temporarily override your package locally.