### PR TITLE
Update esm.mts

### DIFF
--- a/packages/register/esm.mts
+++ b/packages/register/esm.mts
@@ -217,7 +217,7 @@ export const resolve: ResolveHook = async (specifier, context, nextResolve) => {
   // local project file
   if (path && isPathNotInNodeModules(path)) {
     debug('resolved: typescript', specifier, path)
-    const url = new URL(join('file://', path))
+    const url = new URL('file://' + join(path))
     return addShortCircuitSignal({
       ...context,
       url: url.href,


### PR DESCRIPTION
For windows users for some reason in some import relative "./importname" the files inside the join was resulting in ".\\file:\\..." Generating error, so I just moved the file:// out of the path, ensuring that it would look correctly and work on Windows

![image](https://github.com/user-attachments/assets/366a5198-c250-4416-a48d-95eb21397d25)
