### PR TITLE
Fix support for 2022-03 decorators

### DIFF
--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -45,11 +45,12 @@ function transformOption(path: string, options?: Options, jest = false): SwcOpti
           parser: {
             syntax: 'typescript' as const,
             tsx: typeof opts.jsx !== 'undefined' ? opts.jsx : path.endsWith('.tsx'),
-            decorators: Boolean(opts.experimentalDecorators),
+            decorators: true,
             dynamicImport: Boolean(opts.dynamicImport),
           },
           transform: {
             legacyDecorator: Boolean(opts.experimentalDecorators),
+            decoratorVersion: Boolean(opts.experimentalDecorators) ? '2021-12' : '2022-03',
             decoratorMetadata: Boolean(opts.emitDecoratorMetadata),
             useDefineForClassFields: Boolean(opts.useDefineForClassFields),
             react: options?.react,


### PR DESCRIPTION
This fixes issue #773.

In fact, I've made a similar PR to ts-node before at their [#2136](https://github.com/TypeStrong/ts-node/pull/2136), but ts-node has been long inactive. So hopefully we can get things work over here 🙏