### PR TITLE
feat(register): respect -C/--conditions flags in ESM

### DIFF
--- a/packages/register/esm.mts
+++ b/packages/register/esm.mts
@@ -11,6 +11,7 @@ import { extname, isAbsolute, join } from 'node:path'
 import { fileURLToPath, parse as parseUrl, pathToFileURL } from 'node:url'
 
 import debugFactory from 'debug'
+import { getConditions } from 'get-conditions'
 import { EnforceExtension, ResolverFactory } from 'oxc-resolver'
 import ts from 'typescript'
 
@@ -40,7 +41,7 @@ const resolver = new ResolverFactory({
     configFile: TSCONFIG_PATH,
     references: 'auto',
   },
-  conditionNames: ['node', 'import'],
+  conditionNames: ['import'].concat(getConditions()),
   enforceExtension: EnforceExtension.Auto,
   extensions: ['.js', '.mjs', '.cjs', '.ts', '.tsx', '.mts', '.cts', '.json', '.wasm', '.node'],
   extensionAlias: {

--- a/packages/register/package.json
+++ b/packages/register/package.json
@@ -44,6 +44,7 @@
     "@swc-node/sourcemap-support": "^0.5.1",
     "colorette": "^2.0.20",
     "debug": "^4.3.5",
+    "get-conditions": "^1.0.0",
     "oxc-resolver": "^8.0.0",
     "pirates": "^4.0.6",
     "tslib": "^2.6.3"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -241,6 +241,9 @@ importers:
       debug:
         specifier: ^4.3.5
         version: 4.3.7
+      get-conditions:
+        specifier: ^1.0.0
+        version: 1.0.0
       oxc-resolver:
         specifier: ^8.0.0
         version: 8.0.0
@@ -2827,6 +2830,9 @@ packages:
     resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
     engines: {node: 6.* || 8.* || >= 10.*}
 
+  get-conditions@1.0.0:
+    resolution: {integrity: sha512-9wKpu0AjWat7OKzvChkghCCkLmYwc3lUbRP5xDSNI4+SrK4599OXcmJamgpU3pNBUOuaKjSg1NE/6ukFSC8kSA==}
+
   get-east-asian-width@1.3.0:
     resolution: {integrity: sha512-vpeMIQKxczTD/0s2CdEWHcb0eeJe6TFjxb+J5xgX7hScxqrGuyjmv4c1D4A/gelKfyox0gJJwIHF+fLjeaM8kQ==}
     engines: {node: '>=18'}
@@ -4311,6 +4317,10 @@ packages:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
 
+  shell-quote@1.8.3:
+    resolution: {integrity: sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==}
+    engines: {node: '>= 0.4'}
+
   signal-exit@3.0.7:
     resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
 
@@ -4619,6 +4629,9 @@ packages:
   type-fest@0.8.1:
     resolution: {integrity: sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==}
     engines: {node: '>=8'}
+
+  type-flag@3.0.0:
+    resolution: {integrity: sha512-3YaYwMseXCAhBB14RXW5cRQfJQlEknS6i4C8fCfeUdS3ihG9EdccdR9kt3vP73ZdeTGmPb4bZtkDn5XMIn1DLA==}
 
   typedarray@0.0.6:
     resolution: {integrity: sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==}
@@ -7756,6 +7769,11 @@ snapshots:
 
   get-caller-file@2.0.5: {}
 
+  get-conditions@1.0.0:
+    dependencies:
+      shell-quote: 1.8.3
+      type-flag: 3.0.0
+
   get-east-asian-width@1.3.0: {}
 
   get-package-type@0.1.0: {}
@@ -9551,6 +9569,8 @@ snapshots:
 
   shebang-regex@3.0.0: {}
 
+  shell-quote@1.8.3: {}
+
   signal-exit@3.0.7: {}
 
   signal-exit@4.1.0: {}
@@ -9859,6 +9879,8 @@ snapshots:
   type-fest@0.6.0: {}
 
   type-fest@0.8.1: {}
+
+  type-flag@3.0.0: {}
 
   typedarray@0.0.6: {}
 


### PR DESCRIPTION
This fixes #890, and my usage.  I think every package using subpath imports in `package.json` instead `paths` rewriting in `.swcrc` will need to use conditions, and therefore will need this change to support switching to ESM.

The `get-conditions` package parses `process.argv` and `process.env.NODE_OPTIONS`, and also adds `"node"`, and, if `--no-addons` hasn't been set, `"node-options"`.