### PR TITLE
feat(register): add new env `SWC_NODE_INLINE_SOURCE_MAP`

### DIFF
--- a/packages/register/read-default-tsconfig.ts
+++ b/packages/register/read-default-tsconfig.ts
@@ -122,12 +122,15 @@ function getUseDefineForClassFields(compilerOptions: ts.CompilerOptions, target:
 export function tsCompilerOptionsToSwcConfig(options: ts.CompilerOptions, filename: string): Options {
   const isJsx = filename.endsWith('.tsx') || filename.endsWith('.jsx') || Boolean(options.jsx)
   const target = options.target ?? ts.ScriptTarget.ES2018
+
+  const enableInlineSourceMap = options.inlineSourceMap ?? Boolean(process.env.SWC_NODE_INLINE_SOURCE_MAP)
+
   return {
     module: toModule(options.module ?? ts.ModuleKind.ES2015),
     target: toTsTarget(target),
     jsx: isJsx,
     // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-    sourcemap: options.sourceMap || options.inlineSourceMap ? 'inline' : Boolean(options.sourceMap),
+    sourcemap: options.sourceMap || enableInlineSourceMap ? 'inline' : Boolean(options.sourceMap),
     experimentalDecorators: options.experimentalDecorators ?? false,
     emitDecoratorMetadata: options.emitDecoratorMetadata ?? false,
     useDefineForClassFields: getUseDefineForClassFields(options, target),
@@ -155,7 +158,7 @@ export function tsCompilerOptionsToSwcConfig(options: ts.CompilerOptions, filena
     ignoreDynamic: Boolean(process.env.SWC_NODE_IGNORE_DYNAMIC),
     swc: {
       sourceRoot: options.sourceRoot,
-      inputSourceMap: options.inlineSourceMap,
+      inputSourceMap: enableInlineSourceMap,
     },
   }
 }

--- a/packages/register/read-default-tsconfig.ts
+++ b/packages/register/read-default-tsconfig.ts
@@ -123,7 +123,11 @@ export function tsCompilerOptionsToSwcConfig(options: ts.CompilerOptions, filena
   const isJsx = filename.endsWith('.tsx') || filename.endsWith('.jsx') || Boolean(options.jsx)
   const target = options.target ?? ts.ScriptTarget.ES2018
 
-  const enableInlineSourceMap = options.inlineSourceMap ?? Boolean(process.env.SWC_NODE_INLINE_SOURCE_MAP)
+  const enableInlineSourceMap =
+    options.inlineSourceMap ??
+    (typeof process.env.SWC_NODE_INLINE_SOURCE_MAP === 'string'
+      ? Boolean(process.env.SWC_NODE_INLINE_SOURCE_MAP)
+      : undefined)
 
   return {
     module: toModule(options.module ?? ts.ModuleKind.ES2015),


### PR DESCRIPTION
The PR adds the `SWC_NODE_INLINE_SOURCE_MAP` alongside the existing tscofig options. It is useful when the source map is needed with `@swc-node/register` w/o changing other bundlers/compilers/linters' behavior.

----

Currently, I have a `tsconfig.json` that, with source map disabled, is used to build the dist and run some maintenance scripts with `@swc-node/register`, and it works great.

However, to get the correct stacktrace and coverage report with `mocha` and `nyc`, I will need to enable sourcemap. Currently, it requires an extra `tsconfig` file **specifically** for `@swc-node/register` to enable source map for tests:

```jsonc
// tsconfig.test-swc.json
{
  "extends": "./tsconfig.json",
  "compilerOptions": {
    "inlineSourceMap": true
  }
}
```
```bash
# Then run the test with the command
SWC_NODE_IGNORE_DYNAMIC=1 SWC_NODE_PROJECT=tsconfig.test-swc.json nyc mocha \
  --require @swc-node/register --full-trace ./src/**/*.test.ts
```

With this PR, it is possible to achieve that w/o an extra `tsconfig` file and `SWC_NODE_PROJECT`, only a command with an extra env `SWC_NODE_INLINE_SOURCE_MAP=1`:

```bash
SWC_NODE_IGNORE_DYNAMIC=1 SWC_NODE_INLINE_SOURCE_MAP=1 nyc mocha \
  --require @swc-node/register --full-trace ./src/**/*.test.ts
```